### PR TITLE
Test nova json schemas

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
                ]}.
 
 {deps, [
-        {nova, ".*", {git, "https://github.com/novaframework/nova.git", {branch, "master"}}}
+        {nova_json_schemas, {git, "https://github.com/novaframework/nova_json_schemas", {branch, "master"}}}
        ]}.
 
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -2,17 +2,14 @@ Conf0 = CONFIG,
 
 NovaBranch = list_to_binary(os:getenv("NOVA_BRANCH", "master")),
 
-Deps = case NovaBranch of
-            <<"master">> -> {deps, [
-              {nova, ".*", {git, "https://github.com/novaframework/nova.git", {branch, "master"}}}
-             ]};
-             <<"refs/tags/", Rest/binary>> ->
-              {deps, [{nova, ".*", {git, "https://github.com/novaframework/nova.git", {tag, binary_to_list(Rest)}}}]};
-             NovaBranch -> {deps, [
-              {nova, ".*", {git, "https://github.com/novaframework/nova.git", {branch, binary_to_list(NovaBranch)}}}
-             ]}
+Deps = proplists:get_value(deps, Conf0),
+NovaDeps = case NovaBranch of
+            <<"master">> -> {nova, {git, "https://github.com/novaframework/nova.git", {branch, "master"}}};
+             <<"refs/tags/", Rest/binary>> -> {nova, {git, "https://github.com/novaframework/nova.git", {tag, binary_to_list(Rest)}}};
+             NovaBranch -> {nova, {git, "https://github.com/novaframework/nova.git", {branch, binary_to_list(NovaBranch)}}}
             end,
+Deps2 = {deps, [NovaDeps|Deps]},
+
 Conf1 = proplists:delete(deps, Conf0),
 
-[Deps|Conf1].
-
+[Deps2|Conf1].

--- a/src/nova_request_app.app.src
+++ b/src/nova_request_app.app.src
@@ -9,7 +9,8 @@
    [
     kernel,
     stdlib,
-    nova
+    nova,
+    nova_json_schemas
    ]},
   {env,[]},
   {modules, []},

--- a/src/nova_request_app_router.erl
+++ b/src/nova_request_app_router.erl
@@ -79,6 +79,16 @@ with_fun() ->
         security => false,
         routes => [
                     {"/", fun nova_request_app_main_controller:get_user/1, #{methods => [get]}},
-                    {"/", fun nova_request_app_main_controller:delete_user/1, #{methods => [delete]}}
-
-      ]}].
+                    {"/", fun nova_request_app_main_controller:delete_user/1, #{methods => [delete]}}]
+       },
+      #{prefix => "/fun/json_schemas",
+          security => false,
+          plugins => [
+                      {pre_request, nova_request_plugin, #{decode_json_body => true}},
+                      {pre_request, nova_json_schemas, #{render_errors => true}}
+                      ],
+          routes => [
+                      {"/", fun(_) -> {status, 200} end,
+                      #{methods => [post], extra_state => #{ json_schema => "./schemas/sample_json_schema.json" }}}]
+       }
+].

--- a/test/nova_request_app_fun_SUITE.erl
+++ b/test/nova_request_app_fun_SUITE.erl
@@ -125,7 +125,10 @@ all() ->
      fallback,
      view_with_ok,
      view_with_view,
-     heartbeat].
+     heartbeat,
+     json_schema_ok,
+     json_schema_validation_error
+].
 %%--------------------------------------------------------------------
 %% @spec TestCase(Config0) ->
 %%               ok | exit() | {skip,Reason} | {comment,Comment} |
@@ -238,6 +241,17 @@ view_with_view(_) ->
 heartbeat(_) ->
     Path = [?BASEPATH, <<"heartbeat">>],
     #{status := {200, _}} = jhn_shttpc:get(Path, opts(json_get)).
+
+json_schema_ok(_) ->
+    Path = [?BASEPATH, <<"json_schemas">>],
+    Json = #{<<"a_string">> => <<"whatever">>},
+    #{status := {200, _}} = jhn_shttpc:post(Path, encode(Json), opts(json_post)).
+json_schema_validation_error(_) ->
+    Path = [?BASEPATH, <<"json_schemas">>],
+    Json = #{<<"a_string">> => 5},
+    #{status := {400, _}, body := Body} = jhn_shttpc:post(Path, encode(Json), opts(json_post)),
+    ct:pal("Body: ~p~njson:decode(Body): ~p~n", [Body, json:decode(Body)]),
+    [#{<<"error_type">> := <<"wrong_type">>}] = json:decode(Body).
 
 ws(_) ->
     Wohoo = <<"wohoo">>,


### PR DESCRIPTION
This adds the `nova_json_schemas` plugin, and a few tests for that as well. 

Running the tests with `NOVA_BRANCH=refs/tags/v0.12.1 rebar3 ct` (because nova 0.13.x) currently does not work with `nova_json_schemas` procudes this output, highlighting the fact that the encoded JSON from the `render_error/1` function in the plugin will generate an iolist which will then be encoded into json as a list of integers. This will be parsed and decoded by `thoas` as a list with a string. 

I would really expect a binary string here, and it is probably a good idea if the encoded json can be parsed correctly by json implementations in other languages.

This is what it looks like in Python, for instance:

```
>>> s = "[{\"error_type\":[[119,114,111,110,103,95,116,121,112,101]],\"actual_value\":5,\"error_context\":\"schema_violation\",\"expected_value\":[\"a_string\"],\"field_info\":{\"type\":\"string\"}}]"
>>> json.loads(s)
[{'error_type': [[119, 114, 111, 110, 103, 95, 116, 121, 112, 101]], 'actual_value': 5, 'error_context': 'schema_violation', 'expected_value': ['a_string'], 'field_info': {'type': 'string'}}]
```

```
% NOVA_BRANCH=refs/tags/v0.12.1 rebar3 ct
===> Verifying dependencies...
===> Running erlydtl...
===> Analyzing applications...
===> Compiling nova_request_app
   ┌─ test/nova_request_app_fun_SUITE.erl:
   │
 3 │  -compile(export_all).
   │   ╰── Warning: export_all flag enabled - all functions will be exported

    ┌─ test/nova_request_app_fun_SUITE.erl:
    │
 35 │  end_per_suite(Config) ->
    │                ╰── Warning: variable 'Config' is unused


===> Cover compilation failed: {no_file_attribute,
                                       "/home/marfro/code/github/novaframework/nova_request_app/_build/test/lib/nova_request_app/ebin/nova_request_app_main_dtl.beam"}
===> Running Common Test suites...
=PROGRESS REPORT==== 7-Oct-2025::16:31:57.376029 ===
    supervisor: {local,logger_sup}
    started: [{pid,<0.774.0>},
              {id,cth_log_redirect},
              {mfargs,{gen_server,start_link,
                                  [{local,cth_log_redirect},
                                   cth_log_redirect,[],[]]}},
              {restart_type,transient},
              {significant,false},
              {shutdown,2000},
              {child_type,worker}]

%%% nova_request_app_SUITE: .....................
%%% nova_request_app_fun_SUITE: .......................
=DEBUG REPORT==== 7-Oct-2025::16:31:59.308101 ===
Got validation-errors on JSON body. Errors: [{data_invalid,
                                              #{<<"type">> => <<"string">>},
                                              wrong_type,5,
                                              [<<"a_string">>]}]
=DEBUG REPORT==== 7-Oct-2025::16:31:59.308361 ===
Rendering validation-errors and send back to requester

----------------------------------------------------
2025-10-07 16:31:59.322
Body: <<"[{\"error_type\":[[119,114,111,110,103,95,116,121,112,101]],\"actual_value\":5,\"error_context\":\"schema_violation\",\"expected_value\":[\"a_string\"],\"field_info\":{\"type\":\"string\"}}]">>
json:decode(Body): [#{<<"actual_value">> => 5,
                      <<"error_context">> => <<"schema_violation">>,
                      <<"error_type">> => ["wrong_type"],
                      <<"expected_value">> => [<<"a_string">>],
                      <<"field_info">> => #{<<"type">> => <<"string">>}}]



%%% nova_request_app_fun_SUITE ==> json_schema_validation_error: FAILED
%%% nova_request_app_fun_SUITE ==> {{badmatch,[#{<<"actual_value">> => 5,
              <<"error_context">> => <<"schema_violation">>,
              <<"error_type">> => ["wrong_type"],
              <<"expected_value">> => [<<"a_string">>],
              <<"field_info">> => #{<<"type">> => <<"string">>}}]},
 [{nova_request_app_fun_SUITE,json_schema_validation_error,1,
                              [{file,"/home/marfro/code/github/novaframework/nova_request_app/test/nova_request_app_fun_SUITE.erl"},
                               {line,254}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1796}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1305}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1237}]}]}

EXPERIMENTAL: Writing retry specification at /home/marfro/code/github/novaframework/nova_request_app/_build/test/logs/retry.spec
              call rebar3 ct with '--retry' to re-run failing cases.
Failed 1 tests. Passed 44 tests. 
Results written to "/home/marfro/code/github/novaframework/nova_request_app/_build/test/logs/index.html".
===> Failures occurred running tests: 1
```

--- 

This is of course not really mergeable as is, since it has broken tests in it, but I still want to highlight the problem.