### PR TITLE
fix: support fork PRs in CI

### DIFF
--- a/.github/workflows/run_nra.yml
+++ b/.github/workflows/run_nra.yml
@@ -7,9 +7,14 @@ on:
         required: true
         type: string
         default: main
+      nova_repo:
+        required: false
+        type: string
+        default: "novaframework/nova"
 
 env:
   NOVA_BRANCH: "${{ inputs.nova_branch }}"
+  NOVA_REPO: "${{ inputs.nova_repo }}"
 jobs:
   run-nra:
     runs-on: ubuntu-22.04

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,15 +1,17 @@
 Conf0 = CONFIG,
 
 NovaBranch = list_to_binary(os:getenv("NOVA_BRANCH", "master")),
+NovaRepo = os:getenv("NOVA_REPO", "novaframework/nova"),
+RepoUrl = "https://github.com/" ++ NovaRepo ++ ".git",
 
 Deps = case NovaBranch of
             <<"master">> -> {deps, [
-              {nova, ".*", {git, "https://github.com/novaframework/nova.git", {branch, "master"}}}
+              {nova, ".*", {git, RepoUrl, {branch, "master"}}}
              ]};
              <<"refs/tags/", Rest/binary>> ->
-              {deps, [{nova, ".*", {git, "https://github.com/novaframework/nova.git", {tag, binary_to_list(Rest)}}}]};
+              {deps, [{nova, ".*", {git, RepoUrl, {tag, binary_to_list(Rest)}}}]};
              NovaBranch -> {deps, [
-              {nova, ".*", {git, "https://github.com/novaframework/nova.git", {branch, binary_to_list(NovaBranch)}}}
+              {nova, ".*", {git, RepoUrl, {branch, binary_to_list(NovaBranch)}}}
              ]}
             end,
 Conf1 = proplists:delete(deps, Conf0),


### PR DESCRIPTION
## Summary
- Add `nova_repo` input to the `run_nra.yml` workflow (defaults to `novaframework/nova` for backwards compatibility)
- Set `NOVA_REPO` env var from the new input
- Update `rebar.config.script` to build the git URL from `NOVA_REPO` env var instead of hardcoding `novaframework/nova.git`

## Context
When contributors open PRs from forks, CI fails because `rebar.config.script` hardcodes `https://github.com/novaframework/nova.git`. The branch exists on the fork, not upstream. This change lets the calling workflow pass the correct repo.

## Test plan
- [ ] Existing direct-branch PRs still pass (default `novaframework/nova` preserves current behavior)
- [ ] After merging, a companion PR in `novaframework/nova` will pass fork repo URL — fork PRs should then work

🤖 Generated with [Claude Code](https://claude.com/claude-code)