### PR TITLE
chore: drop OTP 26, update CI versions

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -4,16 +4,16 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
     strategy:
       fail-fast: false
       matrix:
-        otp: ['26.1', '27.1', '28.0']
-        rebar3: ['3.25.0']
+        otp: ['27.3', '28.3']
+        rebar3: ['3.26.0']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{matrix.otp}}

--- a/.github/workflows/run_nra.yml
+++ b/.github/workflows/run_nra.yml
@@ -17,16 +17,16 @@ env:
   NOVA_REPO: "${{ inputs.nova_repo }}"
 jobs:
   run-nra:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
     strategy:
       fail-fast: false
       matrix:
-        otp: ['26.1', '27.1', '28.0']
-        rebar3: ['3.25.0']
+        otp: ['27.3', '28.3']
+        rebar3: ['3.26.0']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: novaframework/nova_request_app
         ref: main


### PR DESCRIPTION
## Summary
- Drop OTP 26.1 from CI matrix (Nova now requires OTP 27+ after switching from thoas to OTP json module)
- Bump OTP versions to 27.3/28.3
- Bump rebar3 to 3.26.0
- Bump actions/checkout from v4 to v6
- Bump ubuntu runners from 20.04/22.04 to 24.04

Related: novaframework/nova#366

🤖 Generated with [Claude Code](https://claude.com/claude-code)